### PR TITLE
Patch: Default.js using string[] for args

### DIFF
--- a/controllers/default.js
+++ b/controllers/default.js
@@ -16,7 +16,7 @@ function socket() {
     this.on('open', function (client) {
 
         // Spawn terminal
-        client.tty = Pty.spawn('python3', ['app.py repl'], {
+        client.tty = Pty.spawn('python3', ['app.py`, `repl'], {
             name: 'xterm-color',
             cols: 150,
             rows: 48,


### PR DESCRIPTION
Line 19: add series of cmd line args, 
Not `['app.py repl']`
But `['app.py`, `repl']`

