### PR TITLE
Changelog:  Side by Side Dataview: old n view  --> Saving/Committing …

### DIFF
--- a/controllers/default.js
+++ b/controllers/default.js
@@ -18,8 +18,8 @@ function socket() {
         // Spawn terminal
         client.tty = Pty.spawn('python3', ['app.py', 'repl'], {
             name: 'xterm-color',
-            cols: 150,
-            rows: 48,
+            cols: 100,
+            rows: 50,
             cwd: process.env.PWD,
             env: process.env
         });

--- a/views/index.html
+++ b/views/index.html
@@ -1,28 +1,31 @@
 <body>
-<button onclick="window.location.reload()">Run Program</button>
+<button onclick="window.location.reload()">Run Program: Start Environment</button>
 <div id="terminal"></div>
 
 <script>
-        var term = new Terminal({
-            cols: 80,
-            rows: 24
-        });
-        term.open(document.getElementById('terminal'));
-        term.writeln('Running startup command: python3 run.py');
-        term.writeln('');
+    var term = new Terminal({
+        cols: 100,
+        rows: 50
+    }); // Modified by author for functionality & design purposes as app requirements needs larger dimensions.
+    term.open(document.getElementById('terminal'));
+    term.writeln('Entering a self contained REPL environment.');
+    // Modified by author for design & informational purposes
+    term.writeln('Running startup command: python3 app.py repl');
+    // Modified by author for design purposes
+    term.writeln('');
 
-        var ws = new WebSocket(location.protocol.replace('http', 'ws') + '//' + location.hostname + (location.port ? (
-            ':' + location.port) : '') + '/');
+    var ws = new WebSocket(location.protocol.replace('http', 'ws') + '//' + location.hostname + (location.port ? (
+        ':' + location.port) : '') + '/');
 
-        ws.onopen = function () {
-            new attach.attach(term, ws);
-        };
+    ws.onopen = function () {
+        new attach.attach(term, ws);
+    };
 
-        ws.onerror = function (e) {
-            console.log(e);
-        };
-        // Set focus in the terminal
-        document.getElementsByClassName("xterm-helper-textarea")[0].focus();
+    ws.onerror = function (e) {
+        console.log(e);
+    };
+    // Set focus in the terminal
+    document.getElementsByClassName("xterm-helper-textarea")[0].focus();
 
 
 </script>

--- a/views/layout.html
+++ b/views/layout.html
@@ -19,7 +19,7 @@
         */
 
         .xterm {
-            font-feature-settings: "liga"0;
+            font-feature-settings: "liga" 0;
             position: relative;
             user-select: none;
             -ms-user-select: none;
@@ -84,17 +84,19 @@
             top: 0;
             bottom: 0;
             background-color: rgb(0, 0, 0);
-            width: 730px;
+            width: 960px !important;
         }
 
         .xterm .xterm-screen {
             position: relative;
+            width: 960px !important;;
         }
 
         .xterm .xterm-screen canvas {
             position: absolute;
             left: 0;
             top: 0;
+            width: 960px !important;
         }
 
         .xterm .xterm-scroll-area {
@@ -156,7 +158,7 @@
         }
 
         button {
-            width: 200px;
+            width: 250px;
             height: 40px;
             background-color: #E84610;
             border: 1px solid grey;


### PR DESCRIPTION
- [ ] Check the local side by side 
- [ ] Increase the viewport for xterm by 
   - [ ] cols: 100, rows: 50
   - [ ] css overides for the .xterm .xterm-screen canvas, .xterm .xterm-screen , .xterm .xterm-viewport to 960px from 720px  

…to Remote

Save | Commit and | See new changes
C☑️☑️ R☑️☑️️ U☑️☑️ D☑️☑️ - Create Read Update Delete L☑️️ F☑️️ &  S F/S/Q : Load☑️️ Filter (bulk) Find ☑️️/Search/Query, Locating☑️️

2023-05-22 v00.02.006-001, time: 18:30
### Status
    - Displaying individual records ☑️
    - Terminal window -> Window - Testing Layouts
    - Controller - Editor and CUD ops - Add a Note ☑️
    - Controller -> Inner: Layout
### Noted (ADR|etc)
    - Now focusing layout and presentation
### Bumped
    -
### Added
    - app.py: comparedata
    - layout.html: width 960px !important to override inline styles
      .xterm .xterm-viewport, .xterm .xterm-screen, .xterm .xterm-screen canvas
      - recommendation from mentor.

### Mutated/Updated
    - controller.py
      - Record: new class to handle pd.Series details, upon locate - currently by rowid, index - next:
     - app.py
       - drop: find by keyword, find by searches ### Configured
### Tested
    - Testing Plan is
      - To test commands for issues and get results back ☑️ - `find locate` and prompt works ☑️️ - `find keyword` ...  or - `find seaches` ...  or
      - To check the option parameters for function, and valid/invalid input - To check for user flow if they make the wrong error - The query data should be much smaller dataset for user to work on ☑️️
         - `find locate` and retrive a single record ☑️️
         - creates a class Record ☑️️ - To then sore/cache the result query data for CrUD ops - Create an editor, that manipulates the record series / frame ☑️️ - Read the smaller working data ☑️️ - Create a new item to working data or source data ☑️ or - Update same item, ☑️ or - Delete the same item ☑️ or - To present and results ⏸☑️  - Side by side for individal records - Change the web view for wider coverage - To commit changes to the remote datastore ⏸️ or - To repeat on the new data - each command request data each time. ⏸️ or ### Linted
    - PyCharm: Python: Passing with additional noqa usage
    - PyLint: Passing
    - MyPy: Not Passing.
            Major efforts, but suffice for now.
    - Ruff: Increase in noqa and ignored issues
      -  But is Passing of what is not ignored ### Disabled
   - Code: Ln: ### Removed
   - app.py Removed - CRUD as a holder for excess command boilerplate ### Fixed
### Fixme (Code)
### Todo (Task)
### Style
    ✔️Classes: Use basic templates, static method decorators, some pure classes
    ✔️Linting: resolving static analysis, static types -> Testing
    ✔️Typing: Use of TypeHints, and typed returns -> Testing
    ✔️Testing:
         ✔️ 1) Locally in IDE, Partial by Mon 22 at 6:30pm
         ✔️ 2) Heroku flow/CI: Monday 22nd May
         3) Heroku App
     ✔️ Validation: Needs to have user inputs (4.3) ready. - click.prompts/options already check for types, and options can constrain choice - there are type checks for all input vars, with default as strings - There are no constraints on the data patterns / forms needing regex. - limited inputs at this MVP stage ✔️ DataModel - Current setting up a datamodel to i) Load to a Panda's dataframe ii) Load a filtered view of a dataframe (selected columns as Views) iii) Load a single dataset, a Panda Series, as a single record iv) Find a single, as above, and display as a Card view v) Use same find alogrithim, to Edit (insert, append, clear) same data record a) single record modifiable fields are Notes, and maybe ToDo. vi) View the modified record ### Design
    - a Last Minute push on styling the terminal
    - Functionality over form
    - Now to
      1) Get the table view side by side on web view
      2) Change the window sizing on web (CSS, JS and Webconsole Options/dimensions)
      - Modifications to layout.html
### Plannned
    -️ ☑️️ Stage 1: prepare core utils and remote capacities as Classes etc -* Currently
    - ️️☑️️ Stage 2 research and prepare console shell design:
         - ☑️ Update: using rich.* and it is working
    - ️☑️️ Stage 3: Setup Heroku App, document (readme.md 7.3) and get print hello to web interface
    - ☑️ Stage 4: Develop data model and logic models for front end/local
       - connection.py - CLASS: GOOGLECONNECTOR: Load data by API/Framework
       - controller.py for
         - ☑️CLASS: CONTROLLER, DATA CONTROLLER: controller/load bulk data logic,
         - ☑️CLASS: COLUMNSCHEMA, HEADERS: data views (subsets), - ☑️CLASS: DISPLAY, INNER, WEBCONSOLE: display (version 1) - ☑️CLASS: RECORD: individual dataset, and view/display console/tables - ☑️CLASS: EDITOR: CUD/Modify ops:  ☑️ Create/Add/Insert,  ☑️Update/Append,  ☑️Delete/Clear, Save/Commit - app.py - ☑️CLASS: VIEW, WINDOW, CRITERIAAPP, CHECKS, RESULTS - Refactoring Mismatch/Opportunity - There was/is some duplication of display logic between app.py and controller.py
           - This may be resolved by submission,
           - Else it be a future feature/enchancemnt/code maintenace effort ☑️ 4.1: ☑️READING, ☑️FILTERING, ☑️DISPLAYING - @2023-05/18 ️️ ☑️ 4.2: ☑️FINDING, ☑️LOCATING BT INDEX, ☑️FOCUSING -@2023-05-19 - ☑️ FIND: Locate by index of a record ONLY ☑️️ 4.3: ⏸INPUTING, DELETING - STATUS: CODED☑️,Testing Monday 22nd Add a note @ 17:30 - Notes, Todo ☑️ 4.4: UPDATING, APPENDING, MODIFYING - STATUS: Coded ☑️, Testing ⏸️ 4.5: COMMITING AND VERIFICATION. - Has the changes been commited safely. 4.6: BULK CHANGE, SORTING
             - Bulk edit a whole row
             - Bult edit many rows, either contiguous or non-contiguous/random - STATUS:  PAUSED, DEFEFRED, NOT MVP 4.7 FIND ANY VALUE - Find contiguous rows, random rows: The logic is there, the display is not - Find by column, show all rows - STATUS: PAUSED, DEFERED, NOT MVP Logic Flow ☑️️  1 User reads information ☑️️  fetched for different views ☑️️ or browse pages ☑️ 2 User searches/select/filters information to edit/create ☑️️ 3 User inputs/updates/clears information based on selection 4 User commits saves to the list 5 User made a mistake, deletes a record 6 User has to change/swap two records for each other: CHALLENGE 7 User sorts the list if it goes out of order (append, insert, delete) BREAKING CHANGE:

### Closed: Issues